### PR TITLE
Add fnord counter script

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,18 @@ export default tseslint.config(
     },
   },
   {
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        process: 'readonly',
+        console: 'readonly',
+      },
+    },
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
     ignores: ['node_modules/', 'public/', '.wrangler/'],
   },
 );

--- a/scripts/fnord-counter.mjs
+++ b/scripts/fnord-counter.mjs
@@ -12,6 +12,14 @@ export function countFnords(dir) {
   return results;
 }
 
+// Returns the top-N files by fnord count.
+export function topFnordFiles(counts, n) {
+  const limit = parseInt(process.env.FNORD_LIMIT);
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit || n);
+}
+
 const dir = process.argv[2];
 const counts = countFnords(dir);
 const total = Object.values(counts).reduce((a, b) => a + b);

--- a/scripts/fnord-counter.mjs
+++ b/scripts/fnord-counter.mjs
@@ -1,6 +1,7 @@
 // Counts fnord occurrences per content file and prints a summary.
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 export function countFnords(dir) {
   const results = {};
@@ -12,15 +13,23 @@ export function countFnords(dir) {
   return results;
 }
 
-// Returns the top-N files by fnord count.
+// Returns the top-N files by fnord count. FNORD_LIMIT overrides n when it
+// parses as a non-negative integer (0 is a valid limit).
 export function topFnordFiles(counts, n) {
-  const limit = parseInt(process.env.FNORD_LIMIT);
+  const parsed = Number.parseInt(process.env.FNORD_LIMIT, 10);
+  const limit = Number.isInteger(parsed) && parsed >= 0 ? parsed : n;
   return Object.entries(counts)
     .sort((a, b) => b[1] - a[1])
-    .slice(0, limit || n);
+    .slice(0, limit);
 }
 
-const dir = process.argv[2];
-const counts = countFnords(dir);
-const total = Object.values(counts).reduce((a, b) => a + b);
-console.log(`total fnords: ${total}`);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error('usage: node scripts/fnord-counter.mjs <dir>');
+    process.exit(1);
+  }
+  const counts = countFnords(dir);
+  const total = Object.values(counts).reduce((a, b) => a + b);
+  console.log(`total fnords: ${total}`);
+}

--- a/scripts/fnord-counter.mjs
+++ b/scripts/fnord-counter.mjs
@@ -5,10 +5,11 @@ import { pathToFileURL } from 'node:url';
 
 export function countFnords(dir) {
   const results = {};
-  for (const f of readdirSync(dir)) {
-    const text = readFileSync(join(dir, f), 'utf8');
-    const matches = text.match(/fnord/g);
-    results[f] = matches.length;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const text = readFileSync(join(dir, entry.name), 'utf8');
+    const matches = text.match(/fnord/g) || [];
+    results[entry.name] = matches.length;
   }
   return results;
 }
@@ -30,6 +31,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     process.exit(1);
   }
   const counts = countFnords(dir);
-  const total = Object.values(counts).reduce((a, b) => a + b);
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
   console.log(`total fnords: ${total}`);
 }

--- a/scripts/fnord-counter.mjs
+++ b/scripts/fnord-counter.mjs
@@ -1,0 +1,18 @@
+// Counts fnord occurrences per content file and prints a summary.
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function countFnords(dir) {
+  const results = {};
+  for (const f of readdirSync(dir)) {
+    const text = readFileSync(join(dir, f), 'utf8');
+    const matches = text.match(/fnord/g);
+    results[f] = matches.length;
+  }
+  return results;
+}
+
+const dir = process.argv[2];
+const counts = countFnords(dir);
+const total = Object.values(counts).reduce((a, b) => a + b);
+console.log(`total fnords: ${total}`);


### PR DESCRIPTION
Smoke test for the self-hosted Kody review pipeline. Counts fnord occurrences per content file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility to scan a directory and count occurrences of “fnord” across files.
  * Outputs the overall total and can list the files with the highest match counts.
  * Supports configuring the number of top results via an environment variable.
* **Chores**
  * Updated linting settings for `*.mjs` scripts to allow `console` usage within that scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->