### PR TITLE
fix(chunking): hard-split oversized paragraphs in chunkText

### DIFF
--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -64,6 +64,14 @@ function chunkText(text: string, maxChars = 1500): string[] {
       chunks.push(current.trim());
       current = '';
     }
+    // A single paragraph can exceed maxChars on its own; hard-split it so no
+    // chunk is silently oversized (embedding models truncate past their limit).
+    if (para.length > maxChars) {
+      for (let i = 0; i < para.length; i += maxChars) {
+        chunks.push(para.slice(i, i + maxChars).trim());
+      }
+      continue;
+    }
     current += para + '\n\n';
   }
   if (current.trim()) chunks.push(current.trim());

--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -66,7 +66,7 @@ function chunkText(text: string, maxChars = 1500): string[] {
     }
     // A single paragraph can exceed maxChars on its own; hard-split it so no
     // chunk is silently oversized (embedding models truncate past their limit).
-    if (para.length > maxChars) {
+    if (maxChars > 0 && para.length > maxChars) {
       for (let i = 0; i < para.length; i += maxChars) {
         chunks.push(para.slice(i, i + maxChars).trim());
       }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -301,7 +301,7 @@ function chunkText(text: string, maxChars = 1500): string[] {
     }
     // A single paragraph can exceed maxChars on its own; hard-split it so no
     // chunk is silently oversized (embedding models truncate past their limit).
-    if (para.length > maxChars) {
+    if (maxChars > 0 && para.length > maxChars) {
       for (let i = 0; i < para.length; i += maxChars) {
         chunks.push(para.slice(i, i + maxChars).trim());
       }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -299,6 +299,14 @@ function chunkText(text: string, maxChars = 1500): string[] {
       chunks.push(current.trim());
       current = '';
     }
+    // A single paragraph can exceed maxChars on its own; hard-split it so no
+    // chunk is silently oversized (embedding models truncate past their limit).
+    if (para.length > maxChars) {
+      for (let i = 0; i < para.length; i += maxChars) {
+        chunks.push(para.slice(i, i + maxChars).trim());
+      }
+      continue;
+    }
     current += para + '\n\n';
   }
   if (current.trim()) chunks.push(current.trim());


### PR DESCRIPTION
## What

`chunkText()` emitted any paragraph longer than `maxChars` (1500) as a single oversized chunk. The `@cf/baai/bge-base-en-v1.5` embedding model silently truncates input past its token limit, so the tail of such a paragraph was never embedded — degrading semantic search recall for long unbroken passages.

Fix: hard-split any oversized paragraph into `maxChars`-sized pieces before pushing it. Applied to **both** copies of the function (`worker/index.ts` and `scripts/index-content.ts`), per the "keep in sync" note in `CLAUDE.md`.

## Test

- `npm run typecheck` / `npm run lint` / `npm run format` all pass.
- Verified: a 3500-char paragraph now yields 3 chunks (1500/1500/500), none exceeding the limit; normal multi-paragraph text is unchanged.
