### PR TITLE
LAB-1539 simulation: Kody internal-error check conclusion (scratch, do not merge)

### DIFF
--- a/lab1539-sim.txt
+++ b/lab1539-sim.txt
@@ -1,1 +1,2 @@
 LAB-1539 simulation marker — scratch file to trigger a Kody review while the instance model is deliberately broken. Safe to delete.
+second line for healthy-path verification

--- a/lab1539-sim.txt
+++ b/lab1539-sim.txt
@@ -1,0 +1,1 @@
+LAB-1539 simulation marker — scratch file to trigger a Kody review while the instance model is deliberately broken. Safe to delete.


### PR DESCRIPTION
Scratch PR to verify the lab1539 Kodus patch: with the instance LLM model deliberately broken, the Kody Code Review check-run must conclude NEUTRAL (not FAILURE) so the rollup stays non-red. Will be closed after verification. LAB-1539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an internal scratch marker for review workflow testing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->